### PR TITLE
Added optional exception callback function to EventHandler

### DIFF
--- a/sciter/event.py
+++ b/sciter/event.py
@@ -27,7 +27,10 @@ class EventHandler:
         self.set_dispatch_options()
         if window or element:
             self.attach(window, element, subscription)
-        self.script_call_exception_handler = script_call_exception_handler  # callback function to catch exceptions in script calls
+
+        # callback function to catch exceptions in script calls
+        # handler_func(function_name, exception)
+        self.script_call_exception_handler = script_call_exception_handler
 
     def __del__(self):
         assert(not self.element)
@@ -188,7 +191,7 @@ class EventHandler:
                 traceback.print_exc()
                 if self.script_call_exception_handler:
                     # if exception handler is defined, call it with exception as argument
-                    self.script_call_exception_handler(e)
+                    self.script_call_exception_handler(fname, e)
                 rv = e
 
         # if not handled, call decorated method
@@ -204,7 +207,7 @@ class EventHandler:
                 traceback.print_exc()
                 if self.script_call_exception_handler:
                     # if exception handler is defined, call it with exception as argument
-                    self.script_call_exception_handler(e)
+                    self.script_call_exception_handler(fname, e)
                 rv = str(e) if skip_exception else e
 
         # if handled, pack result for Sciter

--- a/sciter/event.py
+++ b/sciter/event.py
@@ -190,7 +190,7 @@ class EventHandler:
                 import traceback
                 traceback.print_exc()
                 if self.script_call_exception_handler:
-                    # if exception handler is defined, call it with exception as argument
+                    # if exception handler is defined, call it with (func_name, exception) as arguments
                     self.script_call_exception_handler(fname, e)
                 rv = e
 
@@ -206,7 +206,7 @@ class EventHandler:
                 import traceback
                 traceback.print_exc()
                 if self.script_call_exception_handler:
-                    # if exception handler is defined, call it with exception as argument
+                    # if exception handler is defined, call it with (func_name, exception) as arguments
                     self.script_call_exception_handler(fname, e)
                 rv = str(e) if skip_exception else e
 


### PR DESCRIPTION
The `script_call_exception_handler` kwarg for the EventHandler class can be used to pass in a function that will be called when an exception occurs inside a script call.

Example:
```python
def exception_handler(func_name, script_exc):
    logger.exception(f"An error has occurred in {func_name}: {str(script_exc)}", exc_info=script_exc)

event_handler = sciter.EventHandler(window=frame, script_call_exception_handler=exception_handler)
```