### PR TITLE
Fixed add x64 dir to path on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check <https://sciter.com> website and its [documentation resources](https://sci
 ## Getting started:
 
 1. Download the [Sciter SDK](https://sciter.com/download/) and extract it somewhere.
-2. Add the corresponding target platform binaries to PATH (`bin`, `bin.osx` or `bin.gtk`) and install Sciter shared library to your [LIBRARY_PATH](https://github.com/sciter-sdk/go-sciter#getting-started).
+2. Add the corresponding target platform binaries to PATH (`bin.win\x64`, `bin.osx` or `bin.gtk`) and install Sciter shared library to your [LIBRARY_PATH](https://github.com/sciter-sdk/go-sciter#getting-started).
 3. Install pysciter: `python3 setup.py install` or `pip install pysciter`.
 4. Run the minimal pysciter sample: `python3 examples/minimal.py`. Also you can run script from zip archive directly: `python3 ./archive.zip` :)
 


### PR DESCRIPTION
It doesn't work if using the 32 bit sciter.dll as in #46 . This PR fixes the readme.