### PR TITLE
Debug output can be conditional

### DIFF
--- a/sciter/host.py
+++ b/sciter/host.py
@@ -38,13 +38,16 @@ class Host():
         _api.SciterSetCallback(hwnd, self._sciter_handler_proc, ctypes.c_void_p(0))
         pass
 
-    def setup_debug(self, hwnd=None):
+    def setup_debug(self, hwnd=None, debug_windows=True, debug_output=True):
         """Setup debug output function for specific window or globally."""
-        ok = _api.SciterSetOption(hwnd, SCITER_RT_OPTIONS.SCITER_SET_DEBUG_MODE, True)
+        ok = _api.SciterSetOption(hwnd, SCITER_RT_OPTIONS.SCITER_SET_DEBUG_MODE, debug_windows)
         if not ok:
             raise sciter.SciterError("Could not set debug mode")
         self._sciter_debug_proc = DEBUG_OUTPUT_PROC(self.on_debug_output)
-        _api.SciterSetupDebugOutput(hwnd, None, self._sciter_debug_proc)
+        if debug_output:
+            _api.SciterSetupDebugOutput(hwnd, None, self._sciter_debug_proc)
+        else:
+            _api.SciterSetupDebugOutput(hwnd, None, DEBUG_OUTPUT_PROC(0))
         pass
 
     def set_option(self, option, value):

--- a/sciter/window.py
+++ b/sciter/window.py
@@ -32,7 +32,13 @@ class Window(sciter.platform.BaseWindow, sciter.host.Host, sciter.event.EventHan
 
         if debug:
             flags = flags | SCITER_CREATE_WINDOW_FLAGS.SW_ENABLE_DEBUG
-            self.setup_debug()
+
+        # New windows can be inspectable.
+        # Debug messages will be printed always.
+        # If you need to disable the debug output,
+        # either call `frame.setup_debug(debug_output=False)`
+        # or override `Host.on_debug_output`.
+        self.setup_debug(debug_windows=debug, debug_output=True)
 
         self.window_flags = flags
         self._title_changed = False


### PR DESCRIPTION
`Host.setup_debug` allows to customize its behavior:
* `debug_windows` allows new windows to be inspectable
* `debug_output` allows Sciter debug messages

By default, new windows are inspectable (depending on `Window(debug=)` constructor) and debug output is always enabled.

If you need to disable the debug output, either call `frame.setup_debug(debug_output=False)` or override `Host.on_debug_output`.