### PR TITLE
#72 Fixed memory leak

### DIFF
--- a/sciter/value.py
+++ b/sciter/value.py
@@ -690,7 +690,7 @@ class value():
     def pack_args(*args, **kwargs):
         """Pack arguments tuple as SCITER_VALUE array."""
         argc = len(args)
-        argv = value_array(array_len=argc)
+        argv = value_array(length=argc)
         for i, v in enumerate(args):
             argv[i] = v
         this = value(kwargs.get('this'))
@@ -715,10 +715,10 @@ class value_array:
     Wrapper for SCITER_VALUE Array
     """
 
-    def __init__(self, array_len: int):
+    def __init__(self, length: int):
         """Return a new sciter value array wrapped object."""
         super().__init__()
-        self.data = (SCITER_VALUE * array_len)()
+        self.data = (SCITER_VALUE * length)()
         self.ptr = ctypes.pointer(self.data)
 
     @property


### PR DESCRIPTION
Fixed memory leak detailed in issue #72.

Added a new wrapper class named `value_array` for `SCITER_VALUE` arrays. It makes it so we can keep track of them throughout their entire lifecycle and clear them from memory once they no longer are in use.

It also simplifies how you interact with them. Instead of:
```python
sciter_array = (SCITER_VALUE * 5)()
sv = sciter.Value(value)
sv.copy_to(sciter_array[0])
```
you can just do:
```python
sciter_array = value_array(length=5)
sciter_array[0] = value
```