### PR TITLE
Fixed error in `script_exception_handler`

### DIFF
--- a/sciter/event.py
+++ b/sciter/event.py
@@ -383,7 +383,6 @@ class EventHandler:
         By default, just prints exception traceback to stderr and then returns it.
         Can be overridden to change script exception handling.
         """
-        print("Python exception in `%s`: %s" % (func_name, repr(exception)))
         import traceback
         traceback.print_tb(exception.__traceback__)
         return exception

--- a/sciter/event.py
+++ b/sciter/event.py
@@ -380,12 +380,12 @@ class EventHandler:
 
     def script_exception_handler(self, func_name, exception):
         """
-        By default, just return passed in exception.
+        By default, just prints exception traceback to stderr and then returns it.
         Can be overridden to change script exception handling.
         """
         print("Python exception in `%s`: %s" % (func_name, repr(exception)))
         import traceback
-        traceback.print_exception(exception)
+        traceback.print_tb(exception.__traceback__)
         return exception
 
     pass


### PR DESCRIPTION
If an exception occurs inside of @sciter.script, EventHandler.script_exception_handler is called. Inside that method, traceback.print_exception(exception) is called, which raises the following exception:
```
Exception ignored on calling ctypes callback function: <bound method EventHandler._element_proc of <app.App object at 0x10e14ea30>>
Traceback (most recent call last):
  File ".../site-packages/sciter/event.py", line 342, in _element_proc
    return self._on_script_call(p.contents)
  File ".../site-packages/sciter/event.py", line 271, in _on_script_call
    exc = self.script_exception_handler(fname, e)
  File ".../site-packages/sciter/event.py", line 388, in script_exception_handler
    traceback.print_exception(exception)
TypeError: print_exception() missing 2 required positional arguments: 'value' and 'tb'
```

This could be fixed by calling `print_exception` with the exception type, exception, and traceback, but I think `traceback.print_tb` might be a better alternative. You just need to pass in the traceback.